### PR TITLE
Added a prefix to attributes

### DIFF
--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -6,29 +6,29 @@
         android:defaultValue="@integer/font_size_default_value"
         android:key="preference_font_size"
         android:title="@string/font_size"
-        speedreader:maxValue="@integer/font_size_max_value"
-        speedreader:minValue="@integer/font_size_min_value"
-        speedreader:setWrapSelectorWheel="true"/>
+        speedreader:vnt_maxValue="@integer/font_size_max_value"
+        speedreader:vnt_minValue="@integer/font_size_min_value"
+        speedreader:vnt_setWrapSelectorWheel="true"/>
 
     <com.vanniktech.vntnumberpickerpreference.VNTNumberPickerPreference
         android:defaultValue="180"
         android:key="preference_body_size"
         android:title="@string/body_size"
-        speedreader:maxValue="250"
-        speedreader:minValue="40"/>
+        speedreader:vnt_maxValue="250"
+        speedreader:vnt_minValue="40"/>
 
     <com.vanniktech.vntnumberpickerpreference.VNTNumberPickerPreference
         android:defaultValue="1"
         android:key="preference_callback"
         android:title="Callback"
-        speedreader:maxValue="10"
-        speedreader:minValue="0"/>
+        speedreader:vnt_maxValue="10"
+        speedreader:vnt_minValue="0"/>
 
     <com.vanniktech.vntnumberpickerpreference.VNTNumberPickerPreference
         android:defaultValue="10"
         android:key="preference_custom_summary"
         android:title="Custom summary"
-        speedreader:maxValue="100"
-        speedreader:minValue="0"/>
+        speedreader:vnt_maxValue="100"
+        speedreader:vnt_minValue="0"/>
 
 </PreferenceScreen>

--- a/library/src/main/java/com/vanniktech/vntnumberpickerpreference/VNTNumberPickerPreference.java
+++ b/library/src/main/java/com/vanniktech/vntnumberpickerpreference/VNTNumberPickerPreference.java
@@ -27,24 +27,24 @@ import android.widget.LinearLayout;
 import android.widget.NumberPicker;
 
 public class VNTNumberPickerPreference extends DialogPreference {
-    private static final int     MIN_VALUE           = 0;
-    private static final int     MAX_VALUE           = 100;
+    private static final int MIN_VALUE = 0;
+    private static final int MAX_VALUE = 100;
     private static final boolean WRAP_SELECTOR_WHEEL = false;
 
-    private int                  mSelectedValue;
-    private final int            mMinValue;
-    private final int            mMaxValue;
-    private final boolean        mWrapSelectorWheel;
-    private NumberPicker         mNumberPicker;
+    private int mSelectedValue;
+    private final int mMinValue;
+    private final int mMaxValue;
+    private final boolean mWrapSelectorWheel;
+    private NumberPicker mNumberPicker;
 
     public VNTNumberPickerPreference(final Context context, final AttributeSet attrs) {
         super(context, attrs);
 
         final TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.VNTNumberPickerPreference);
 
-        mMinValue = a.getInt(R.styleable.VNTNumberPickerPreference_minValue, VNTNumberPickerPreference.MIN_VALUE);
-        mMaxValue = a.getInt(R.styleable.VNTNumberPickerPreference_maxValue, VNTNumberPickerPreference.MAX_VALUE);
-        mWrapSelectorWheel = a.getBoolean(R.styleable.VNTNumberPickerPreference_setWrapSelectorWheel, VNTNumberPickerPreference.WRAP_SELECTOR_WHEEL);
+        mMinValue = a.getInt(R.styleable.VNTNumberPickerPreference_vnt_minValue, VNTNumberPickerPreference.MIN_VALUE);
+        mMaxValue = a.getInt(R.styleable.VNTNumberPickerPreference_vnt_maxValue, VNTNumberPickerPreference.MAX_VALUE);
+        mWrapSelectorWheel = a.getBoolean(R.styleable.VNTNumberPickerPreference_vnt_setWrapSelectorWheel, VNTNumberPickerPreference.WRAP_SELECTOR_WHEEL);
 
         a.recycle();
     }

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -2,9 +2,9 @@
 <resources>
 
     <declare-styleable name="VNTNumberPickerPreference">
-        <attr name="minValue" format="integer"/>
-        <attr name="maxValue" format="integer"/>
-        <attr name="setWrapSelectorWheel" format="boolean"/>
+        <attr name="vnt_minValue" format="integer"/>
+        <attr name="vnt_maxValue" format="integer"/>
+        <attr name="vnt_setWrapSelectorWheel" format="boolean"/>
     </declare-styleable>
 
 </resources>


### PR DESCRIPTION
in order to avoid "attribute has already been defined" with other libs.
Without it, using libs like materialseekbar will make the build failed because the same attribute are declared (I'm gonna send a pull request to this lib too).